### PR TITLE
fixed a issue with cards and categories

### DIFF
--- a/CompetitiveRounds/PreGamePickBanHandler.cs
+++ b/CompetitiveRounds/PreGamePickBanHandler.cs
@@ -538,7 +538,7 @@ namespace CompetitiveRounds
 
             for (int i = 0; i < CardManager.cards.Count; i++)
             {
-                if (CardManager.cards.Values.ToArray()[i].enabled)
+                if (CardManager.cards.Values.ToArray()[i].enabledWithoutSaving)
                 {
                     CardManager.EnableCard(CardManager.cards.Values.ToArray()[i].cardInfo, true);
                 }


### PR DESCRIPTION
Changes `enabled` to `enabledWithoutSaving` to fix an issue with cards enabling on match start if category is disabled  

**Do not upload this to thunderstore before unbound is updated**